### PR TITLE
Refine report comment indicators and leader summary

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,10 +19,12 @@
       --panel-bg:#f8fafc; --card:#ffffff; --line:#e2e8f0;
       --predio:#0ea5e9; --comunidad:#22c55e; --otros:#a855f7; --highlight:#e11d48;
       --text:#0f172a;
+      --resp-col-width:220px; --type-col-width:130px;
 
       --sat:#e0f2ff;   /* sábado (azul muy claro)   */
       --sun:#fee2e2;   /* domingo (rojito)          */
-      --plan0:#ffe4e6; /* planificado = 0 (rojito)  */
+      --comment-bg:#fef9c3; /* comentario */
+      --comment-ring:#facc15;
     }
     *{box-sizing:border-box}
     html,body{height:100%;margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,"Helvetica Neue",Arial,sans-serif;overflow:hidden;}
@@ -93,20 +95,111 @@
     .chip{display:inline-flex;align-items:center;gap:6px;padding:6px 10px;border:1px solid #e2e8f0;border-radius:999px;background:#fff;cursor:pointer;margin-right:6px;margin-bottom:6px}
     .chip input{transform:scale(1.1)}
     .chip.active{background:#eef7ff;border-color:#bfdbfe}
-    .kpi-line{display:flex;gap:10px;flex-wrap:wrap;margin:8px 16px}
-    .kpi{background:#fff;border:1px solid #e5e7eb;border-radius:12px;padding:10px;min-width:160px}
-    .kpi .val{font-weight:800;font-size:20px}
-    table.report{border-collapse:collapse;width:calc(100% - 32px);margin:0 16px 12px}
-    table.report th, table.report td{border:1px solid #e5e7eb;padding:6px 8px;text-align:center;vertical-align:top;background:#fff}
+    #rp_kpiHeader{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:12px;margin:8px 16px 16px}
+    .kpi-card{background:#fff;border:1px solid #e5e7eb;border-radius:12px;padding:14px;display:flex;flex-direction:column;gap:12px}
+    .kpi-card h4{margin:0;font-size:14px;color:#1e293b;font-weight:700}
+    .kpi-metrics{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px}
+    .kpi-metric{background:#f8fafc;border:1px solid #e2e8f0;border-radius:10px;padding:10px;display:flex;flex-direction:column;gap:4px}
+    .kpi-metric .m-label{font-size:12px;color:#64748b;font-weight:600;text-transform:uppercase;letter-spacing:.5px}
+    .kpi-metric .m-val{font-size:24px;font-weight:800;color:#0f172a}
+    .kpi-metric small{color:#64748b;font-size:11px}
+    .kpi-leader-list{display:flex;flex-direction:column;gap:10px}
+    .leader-item{display:flex;flex-direction:column;gap:6px;padding:10px;border:1px solid #e2e8f0;border-radius:10px;background:#f8fafc}
+    .leader-head{display:flex;justify-content:space-between;align-items:center;font-size:14px;color:#0f172a;font-weight:600}
+    .leader-head span:last-child{font-weight:700}
+    .leader-meta{display:flex;flex-wrap:wrap;gap:8px;font-size:12px;color:#475569;align-items:center}
+    .leader-meta .badge{background:#e0f2fe;border:1px solid #bae6fd;border-radius:999px;padding:2px 10px;font-size:12px;color:#0c4a6e}
+    .leader-progress{width:100%;height:8px;background:#e2e8f0;border-radius:999px;overflow:hidden}
+    .leader-progress span{display:block;height:100%;background:#0ea5e9;border-radius:999px 0 0 999px}
+    table.report{border-collapse:collapse;width:auto;min-width:100%;margin:0}
+    table.report th, table.report td{border:1px solid #e5e7eb;padding:6px 8px;text-align:center;vertical-align:top;background:#fff;position:relative}
     th.sticky{position:sticky;z-index:3;background:#f6f6f6}
     td.sticky{position:sticky;z-index:2;background:#fff}
-    th.sticky.l1, td.sticky.l1 { left:0; min-width:220px; text-align:left;}
-    .ovr-input{width:64px;padding:4px 6px;border:1px solid #cbd5e1;border-radius:8px;text-align:center}
+    th.sticky.l1, td.sticky.l1 {
+      left:0;
+      min-width:var(--resp-col-width);
+      width:var(--resp-col-width);
+      text-align:left;
+      background:#fff;
+      z-index:5;
+      box-shadow:2px 0 0 rgba(15,23,42,.05);
+    }
+    th.sticky.l2, td.sticky.l2 {
+      left:var(--resp-col-width);
+      min-width:var(--type-col-width);
+      width:var(--type-col-width);
+      text-align:left;
+      background:#fff;
+      z-index:4;
+      box-shadow:1px 0 0 rgba(15,23,42,.04);
+    }
+    .type-cell{font-weight:600;color:#475569}
+    .resp-cell{font-weight:700;font-size:15px;text-transform:capitalize;padding:0 12px}
+    .ovr-input{width:62px;padding:4px 6px;border:1px solid #cbd5e1;border-radius:8px;text-align:center}
+    #rp_tableWrap{overflow:auto;border:1px solid #eee;border-radius:10px;margin:0 16px 12px;background:#fff;position:relative}
 
     /* Colores especiales en reporte */
     .col-sat{ background:var(--sat) !important; }
     .col-sun{ background:var(--sun) !important; }
-    .plan-zero{ background:var(--plan0) !important; }
+    .plan-zero{ background:transparent !important; }
+
+    .comment-cell{background:var(--comment-bg) !important; box-shadow:inset 0 0 0 1px rgba(250,204,21,.5);}
+    .comment-cell.comment-linked{box-shadow:inset 0 0 0 1px rgba(250,204,21,.35);}
+    .comment-bajada{background:#e5e7eb !important; box-shadow:inset 0 0 0 1px rgba(148,163,184,.6);}
+    .plan-cell{position:relative;display:flex;align-items:center;justify-content:center;gap:6px;padding-right:18px}
+    .plan-cell.readonly{justify-content:flex-start}
+    .plan-cell.readonly span{font-weight:600}
+    .plan-cell.readonly .value{min-width:24px;text-align:center}
+    .comment-pin{
+      position:absolute;top:4px;right:4px;
+      width:18px;height:18px;
+      border-radius:999px;
+      border:1px solid transparent;
+      background:rgba(148,163,184,.12);
+      color:#475569;
+      font-size:11px;line-height:1;
+      display:flex;align-items:center;justify-content:center;
+      cursor:pointer;transition:transform .15s,background .15s,border-color .15s,color .15s;
+      padding:0;
+    }
+    .comment-pin::before{content:"💬";transform:scale(.84);}
+    .comment-pin:hover{transform:scale(1.08);}
+    .comment-pin.empty{background:transparent;color:#94a3b8;}
+    .comment-pin.has-comment{background:rgba(250,204,21,.24);border-color:rgba(250,204,21,.7);color:#92400e;}
+    .comment-pin.bajada{background:#d1d5db;border-color:#94a3b8;color:#334155;}
+
+    /* Hoy */
+    :root{
+      --today-bg:#f5f3ff;
+      --today-ring:rgba(99,102,241,.45);
+      --today-wash:rgba(99,102,241,.18);
+    }
+    .today-col{
+      position:relative;
+      background:var(--today-bg) !important;
+      box-shadow:inset 0 0 0 9999px var(--today-wash);
+    }
+    .today-col::after{
+      content:"";
+      position:absolute;
+      inset:-2px;
+      border:2px solid var(--today-ring);
+      border-radius:8px;
+      pointer-events:none;
+    }
+
+    /* Comentarios en planificado */
+    .comment-preview{display:none}
+    .comment-popover{position:absolute;min-width:240px;max-width:280px;background:#fff;border:1px solid #cbd5e1;border-radius:12px;box-shadow:0 18px 40px rgba(15,23,42,.2);padding:12px;z-index:9000;display:none}
+    .comment-popover.open{display:block}
+    .comment-popover h5{margin:0 0 6px;font-size:13px;color:#334155;font-weight:700}
+    .comment-popover textarea{width:100%;min-height:96px;border:1px solid #cbd5e1;border-radius:8px;padding:6px;font-family:inherit;resize:vertical;color:#0f172a}
+    .comment-popover textarea:focus{outline:2px solid rgba(14,165,233,.35)}
+    .comment-popover .comment-text{font-size:13px;color:#1f2937;white-space:pre-wrap;max-height:160px;overflow:auto}
+    .comment-popover .actions{margin-top:10px;display:flex;justify-content:flex-end;gap:8px;flex-wrap:wrap}
+    .comment-popover .actions button{padding:6px 10px;border-radius:8px;border:1px solid #cbd5e1;background:#f8fafc;color:#1f2937;font-size:12px;cursor:pointer}
+    .comment-popover .actions button.primary{background:#0ea5e9;border-color:#0284c7;color:#fff}
+    .comment-popover .actions button.danger{background:#fee2e2;border-color:#fca5a5;color:#b91c1c}
 
     #chartWrap{margin:12px 16px 16px;border:1px solid #eee;border-radius:10px;padding:10px;background:#fff}
     #rp_detail{margin:0 16px 16px;border:1px dashed #e5e7eb;border-radius:10px;padding:10px;background:#fafafa}
@@ -279,27 +372,72 @@
 
     <div id="rp_chips" class="row" style="margin-top:-8px"></div>
 
-    <div class="kpi-line">
-      <div class="kpi"><div class="label">Total Elaborado (rango, por UNIR)</div><div id="kpi_total" class="val">—</div></div>
-      <div class="kpi"><div class="label">Responsables activos</div><div id="kpi_resps" class="val">—</div></div>
+    <div id="rp_kpiHeader">
+      <div class="kpi-card">
+        <h4>Resumen general</h4>
+        <div class="kpi-metrics">
+          <div class="kpi-metric">
+            <div class="m-label">Planificado</div>
+            <div class="m-val" id="kpiGeneralPlan">—</div>
+            <small id="kpiGeneralPlanRange">—</small>
+          </div>
+          <div class="kpi-metric">
+            <div class="m-label">Elaborado</div>
+            <div class="m-val" id="kpiGeneralDone">—</div>
+            <small id="kpiGeneralDoneRange">—</small>
+          </div>
+          <div class="kpi-metric">
+            <div class="m-label">Avance</div>
+            <div class="m-val" id="kpiGeneralPct">—</div>
+            <small>Elaborado / Planificado</small>
+          </div>
+        </div>
+      </div>
+      <div class="kpi-card">
+        <h4>Resumen acumulado hasta hoy</h4>
+        <div class="kpi-metrics">
+          <div class="kpi-metric">
+            <div class="m-label">Planificado acum.</div>
+            <div class="m-val" id="kpiTodayPlan">—</div>
+            <small id="kpiTodayRange">—</small>
+          </div>
+          <div class="kpi-metric">
+            <div class="m-label">Elaborado acum.</div>
+            <div class="m-val" id="kpiTodayDone">—</div>
+            <small>Hasta hoy</small>
+          </div>
+          <div class="kpi-metric">
+            <div class="m-label">Avance</div>
+            <div class="m-val" id="kpiTodayPct">—</div>
+            <small>Elaborado / Planificado</small>
+          </div>
+        </div>
+      </div>
+      <div class="kpi-card">
+        <h4>Avance por responsable (hasta hoy)</h4>
+        <div class="kpi-leader-list" id="kpiLeaderList"></div>
+      </div>
     </div>
 
-    <div style="overflow:auto;border:1px solid #eee;border-radius:10px;margin:0 16px 12px">
+    <div id="rp_tableWrap">
       <table id="rp_table" class="report"></table>
     </div>
 
     <div id="chartWrap" style="display:none">
-      <canvas id="rp_chart" height="280"></canvas>
+      <canvas id="rp_chart" height="336"></canvas>
     </div>
 
     <div id="rp_detail" style="display:none"></div>
   </aside>
+
+  <div id="commentPopover" class="comment-popover" role="dialog" aria-modal="false"></div>
 
 <script>
 /** ====== CONFIG ====== **/
 const SUPABASE_URL = "https://wbzxbfqowlfmmkwqeyam.supabase.co";
 const SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6IndienhiZnFvd2xmbW1rd3FleWFtIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTY5ODUwMDQsImV4cCI6MjA3MjU2MTAwNH0.mJJ7yID73tUerWE_aiNw3ZE4o-Q9YrT39YN-iS2CksA";
 const client = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+const numberFormatter = new Intl.NumberFormat('es-PE');
 
 /** ====== Helpers de fecha (evitar desfase -05:00) ====== **/
 function parseYmd(ymd){ const [y,m,d] = ymd.split("-").map(Number); return new Date(y, (m||1)-1, d||1); } // Local
@@ -654,10 +792,13 @@ const rpRun    = document.getElementById("rp_run");
 const rpStatus = document.getElementById("rp_status");
 const rpChips  = document.getElementById("rp_chips");
 const rpTable  = document.getElementById("rp_table");
+const rpTableWrap = document.getElementById("rp_tableWrap");
 const rpDetail = document.getElementById("rp_detail");
 const rpToggle = document.getElementById("rp_toggleEdit");
 let rpChart = null;
 let rpEditMode = false;
+const commentPopoverEl = document.getElementById("commentPopover");
+let commentPopoverState = null;
 
 btnOpen.addEventListener("click", openReport);
 btnClose.addEventListener("click", closeReport);
@@ -671,6 +812,7 @@ function openReport(){
 function closeReport(){
   drawer.classList.remove("open");
   drawer.setAttribute("aria-hidden","true");
+  closeCommentPopover();
 }
 rpRun.addEventListener("click", runReport);
 rpToggle.addEventListener("click", ()=>{ rpEditMode = !rpEditMode; rpToggle.textContent = rpEditMode ? "✅ Terminar edición" : "✏️ Editar Planificado"; runReport(); });
@@ -678,7 +820,7 @@ rpToggle.addEventListener("click", ()=>{ rpEditMode = !rpEditMode; rpToggle.text
 /* Por pedido: del 02 al 31 de octubre (año actual) */
 function defaultReportDates(){
   const Y = new Date().getFullYear();
-  rpStart.value = `${Y}-10-02`;
+  rpStart.value = `${Y}-09-02`;
   rpEnd.value   = `${Y}-10-31`;
 }
 
@@ -702,19 +844,161 @@ function selectedResp(){
   return set;
 }
 
+function handleCommentOutside(e){
+  if(!commentPopoverEl || !commentPopoverEl.classList.contains('open')) return;
+  if(commentPopoverEl.contains(e.target)) return;
+  if(commentPopoverState?.anchor && commentPopoverState.anchor.contains(e.target)) return;
+  closeCommentPopover();
+}
+
+function handleCommentEscape(e){
+  if(e.key === 'Escape') closeCommentPopover();
+}
+
+function closeCommentPopover(){
+  if(!commentPopoverEl) return;
+  commentPopoverEl.classList.remove('open');
+  commentPopoverEl.innerHTML = '';
+  commentPopoverEl.setAttribute('aria-modal','false');
+  document.removeEventListener('mousedown', handleCommentOutside);
+  document.removeEventListener('keydown', handleCommentEscape);
+  commentPopoverState = null;
+}
+
+function openCommentPopover({ resp, fecha, anchor, comment, editable }){
+  if(!commentPopoverEl || !anchor) return;
+  if(commentPopoverState && commentPopoverState.anchor === anchor && commentPopoverEl.classList.contains('open')){
+    closeCommentPopover();
+    return;
+  }
+  closeCommentPopover();
+
+  commentPopoverState = { resp, fecha, anchor, editable };
+  const title = `Comentario — ${cap(resp)} (${fecha})`;
+  let inner = `<h5>${esc(title)}</h5>`;
+
+  if(editable){
+    inner += `
+      <textarea id="commentInput" placeholder="Escribe un comentario..."></textarea>
+      <div class="actions">
+        ${comment ? '<button type="button" data-action="delete" class="danger">Eliminar</button>' : ''}
+        <button type="button" data-action="cancel">Cancelar</button>
+        <button type="button" data-action="save" class="primary">Guardar</button>
+      </div>`;
+  }else{
+    const body = comment ? esc(comment).replace(/\n/g,'<br>') : '<span class="muted">Sin comentario</span>';
+    inner += `
+      <div class="comment-text">${body}</div>
+      <div class="actions"><button type="button" data-action="close" class="primary">Cerrar</button></div>`;
+  }
+
+  commentPopoverEl.innerHTML = inner;
+  commentPopoverEl.classList.add('open');
+  commentPopoverEl.setAttribute('aria-modal', editable ? 'true' : 'false');
+
+  requestAnimationFrame(()=>{
+    const rect = anchor.getBoundingClientRect();
+    const popWidth = commentPopoverEl.offsetWidth;
+    const popHeight = commentPopoverEl.offsetHeight;
+    let left = rect.left + window.scrollX + (rect.width/2) - (popWidth/2);
+    const minLeft = window.scrollX + 12;
+    const maxLeft = window.scrollX + window.innerWidth - popWidth - 12;
+    if(left < minLeft) left = minLeft;
+    if(left > maxLeft) left = maxLeft;
+    let top = rect.bottom + window.scrollY + 8;
+    const maxTop = window.scrollY + window.innerHeight - popHeight - 12;
+    if(top > maxTop){
+      top = rect.top + window.scrollY - popHeight - 8;
+      if(top < window.scrollY + 12) top = window.scrollY + 12;
+    }
+    commentPopoverEl.style.left = `${left}px`;
+    commentPopoverEl.style.top = `${top}px`;
+  });
+
+  if(editable){
+    const textarea = commentPopoverEl.querySelector('#commentInput');
+    if(textarea){
+      textarea.value = comment || '';
+      textarea.focus();
+    }
+    const saveBtn = commentPopoverEl.querySelector('[data-action="save"]');
+    if(saveBtn){
+      saveBtn.addEventListener('click', async ()=>{
+        if(!textarea) return;
+        const raw = textarea.value;
+        const trimmed = raw.trim();
+        const payload = { coment: trimmed === '' ? null : raw };
+        try{
+          await savePlanEntry(resp, fecha, payload);
+          rpStatus.textContent = trimmed === '' ? 'Comentario eliminado ✓' : 'Comentario guardado ✓';
+          closeCommentPopover();
+          await runReport();
+        }catch(err){
+          console.error(err);
+          rpStatus.textContent = 'Error al guardar comentario';
+        }
+      });
+    }
+    const cancelBtn = commentPopoverEl.querySelector('[data-action="cancel"]');
+    if(cancelBtn) cancelBtn.addEventListener('click', closeCommentPopover);
+    const deleteBtn = commentPopoverEl.querySelector('[data-action="delete"]');
+    if(deleteBtn){
+      deleteBtn.addEventListener('click', async ()=>{
+        try{
+          await savePlanEntry(resp, fecha, { coment: null });
+          rpStatus.textContent = 'Comentario eliminado ✓';
+          closeCommentPopover();
+          await runReport();
+        }catch(err){
+          console.error(err);
+          rpStatus.textContent = 'Error al eliminar comentario';
+        }
+      });
+    }
+  }else{
+    const closeBtn = commentPopoverEl.querySelector('[data-action="close"]');
+    if(closeBtn) closeBtn.addEventListener('click', closeCommentPopover);
+  }
+
+  document.addEventListener('mousedown', handleCommentOutside);
+  document.addEventListener('keydown', handleCommentEscape);
+}
+
+function scrollReportToToday(idx){
+  if(idx == null || idx < 0) return;
+  if(!rpTableWrap) return;
+  requestAnimationFrame(()=>{
+    const headerRow = rpTable.querySelector('tr');
+    if(!headerRow) return;
+    const target = headerRow.querySelector(`th:nth-child(${idx + 3})`);
+    if(!target) return;
+    const desired = target.offsetLeft - (rpTableWrap.clientWidth/2) + (target.offsetWidth/2);
+    const left = desired < 0 ? 0 : desired;
+    rpTableWrap.scrollTo({ left, behavior: 'smooth' });
+  });
+}
+
 // Tabla 'plan_pred' (responsable, fecha, valor)
 async function fetchPlan(start, end){
   const { data, error } = await client.from("plan_pred")
-    .select("responsable,fecha,valor")
+    .select("responsable,fecha,valor,coment")
     .gte("fecha", start).lte("fecha", end);
   if(error){ console.warn("plan_pred:", error.message); return []; }
   return data||[];
 }
-async function savePlan(resp, fecha, valor){
-  // Guardar solo L-V
+async function savePlanEntry(resp, fecha, patch = {}){
   const dow = parseYmd(fecha).getDay(); // 0=Dom,6=Sab
-  if(dow===0 || dow===6) return; // ignorar finde
-  const payload = { responsable: resp, fecha, valor: Number(valor)||0 };
+  const hasValor = Object.prototype.hasOwnProperty.call(patch, "valor");
+  if(hasValor && (dow===0 || dow===6)) return; // valores solo L-V
+
+  const payload = { responsable: resp, fecha, ...patch };
+  if(!hasValor){
+    const current = window._rp_planCounts?.[resp]?.[fecha];
+    if(typeof current === "number") payload.valor = current;
+  }else{
+    payload.valor = Number(payload.valor)||0;
+  }
+
   const { error } = await client.from("plan_pred")
     .upsert(payload, { onConflict: "responsable,fecha" });
   if(error) throw error;
@@ -726,36 +1010,35 @@ async function runReport(){
   const allowed = selectedResp(); // vacío => todos
 
   rpStatus.textContent = "Cargando…";
+  closeCommentPopover();
   rpDetail.style.display = "none"; rpDetail.innerHTML = "";
 
-  // filas del rango (usamos responsables/fecha_elab comunes)
-  let { data, error } = await client
-    .from("cod_pred")
-    .select("unir,cod_prel,codigo_mtc,comunidad,responsable,fecha_elab")
-    .not("fecha_elab","is",null)
-    .gte("fecha_elab", start)
-    .lte("fecha_elab", end);
-  if(error){ rpStatus.textContent = "Error: "+error.message; return; }
+  const year = parseYmd(start).getFullYear();
+  const generalStart = `${year}-09-01`;
+  const generalEnd = `${year}-10-31`;
 
-  // Deduplicar por UNIR y armar lista de códigos por grupo
-  const groups = new Map(); // unir -> {responsable, fecha, comunidad, codigo_mtc, unirId, cods:[]}
-  (data||[]).forEach(r=>{
-    const resp = (r.responsable||"").toString().trim().toLowerCase();
-    if(allowed.size && !allowed.has(resp)) return;
-    const key = r.unir;
-    if(key == null) return;
-    if(!groups.has(key)){
-      groups.set(key, {
-        responsable: resp,
-        fecha: (r.fecha_elab||"").toString().slice(0,10),
-        comunidad: r.comunidad||"",
-        codigo_mtc: r.codigo_mtc||"",
-        unirId: key,
-        cods: []
-      });
-    }
-    groups.get(key).cods.push(r.cod_prel||"");
-  });
+  const [rangeResp, generalResp, planRows, planRowsGeneral] = await Promise.all([
+    client
+      .from("cod_pred")
+      .select("unir,cod_prel,codigo_mtc,comunidad,responsable,fecha_elab")
+      .not("fecha_elab","is",null)
+      .gte("fecha_elab", start)
+      .lte("fecha_elab", end),
+    client
+      .from("cod_pred")
+      .select("unir,cod_prel,codigo_mtc,comunidad,responsable,fecha_elab")
+      .not("fecha_elab","is",null)
+      .gte("fecha_elab", generalStart)
+      .lte("fecha_elab", generalEnd),
+    fetchPlan(start, end),
+    fetchPlan(generalStart, generalEnd)
+  ]);
+
+  if(rangeResp.error){ rpStatus.textContent = "Error: "+rangeResp.error.message; return; }
+  if(generalResp.error){ console.warn("cod_pred (general):", generalResp.error.message); }
+
+  const groups = buildGroupsMap(rangeResp.data||[], allowed);
+  const generalGroups = buildGroupsMap(generalResp.data||[], allowed);
 
   // Días del rango
   const dFrom = parseYmd(start), dTo = parseYmd(end);
@@ -767,8 +1050,12 @@ async function runReport(){
   const resps = [...new Set([...groups.values()].map(g=>g.responsable))].filter(Boolean).sort();
 
   // Contadores: elaborado por día (por UNIR), plan desde plan_pred
-  const doneCounts = {}; const planCounts = {};
-  resps.forEach(r=>{ doneCounts[r] = Object.fromEntries(dKeys.map(k=>[k,0])); planCounts[r] = Object.fromEntries(dKeys.map(k=>[k,0])); });
+  const doneCounts = {}; const planCounts = {}; const planComments = {};
+  resps.forEach(r=>{
+    doneCounts[r] = Object.fromEntries(dKeys.map(k=>[k,0]));
+    planCounts[r] = Object.fromEntries(dKeys.map(k=>[k,0]));
+    planComments[r] = Object.fromEntries(dKeys.map(k=>[k,null]));
+  });
 
   // Mapa de celdas para detalle
   const cellMapDone = new Map(); // `${resp}|${day}` -> array de grupos {comunidad,codigo_mtc,unirId,cods[]}
@@ -783,61 +1070,154 @@ async function runReport(){
   });
 
   // Traer planificado y volcar al mapa
-  const planRows = await fetchPlan(start, end);
   (planRows||[]).forEach(p=>{
-    const r = (p.responsable||"").toString().trim().toLowerCase();
+    const r = normResp(p.responsable);
     const k = (p.fecha||"").toString().slice(0,10);
-    if(resps.includes(r) && dKeys.includes(k)) planCounts[r][k] = Number(p.valor)||0;
+    if(resps.includes(r) && dKeys.includes(k)){
+      planCounts[r][k] = Number(p.valor)||0;
+      planComments[r][k] = p.coment || null;
+    }
   });
 
-  // KPIs
-  const totalDone = [...groups.values()].length;
-  document.getElementById("kpi_total").textContent = totalDone;
-  document.getElementById("kpi_resps").textContent = resps.length;
+  window._rp_planCounts = planCounts;
+  window._rp_planComments = planComments;
+
+  const todayKey = dateKey(new Date());
+
+  const planDaily = dMeta.map(({key}) => resps.reduce((acc,r)=> acc + (planCounts[r]?.[key]||0), 0));
+  const doneDaily = dMeta.map(({key}) => resps.reduce((acc,r)=> acc + (doneCounts[r]?.[key]||0), 0));
+
+  const todayIdxRaw = dKeys.indexOf(todayKey);
+  let todayIdx = todayIdxRaw;
+  if(todayIdx === -1){
+    todayIdx = -1;
+    dKeys.forEach((k,i)=>{ if(k<=todayKey) todayIdx = i; });
+  }
+
+  const planToToday = todayIdx >=0 ? planDaily.slice(0, todayIdx+1).reduce((acc,v)=>acc+v,0) : 0;
+  const doneToToday = todayIdx >=0 ? doneDaily.slice(0, todayIdx+1).reduce((acc,v)=>acc+v,0) : 0;
+  const todayPct = planToToday ? Math.round((doneToToday/planToToday)*100) : 0;
+
+  const cutoffKey = todayIdx >=0 ? dKeys[todayIdx] : (todayKey < start ? start : end);
+  let cutoffSuffix = '';
+  if(todayIdx === -1 && todayKey < start){ cutoffSuffix = ' (hoy antes del rango)'; }
+  else if(dKeys.length && todayIdx === dKeys.length-1 && todayKey > end){ cutoffSuffix = ' (hoy después del rango)'; }
+
+  const lastIdxForLeader = todayIdx >=0 ? todayIdx : (todayKey < start ? -1 : dMeta.length - 1);
+  const leaders = resps.map(r=>{
+    let planAcc = 0, doneAcc = 0;
+    if(lastIdxForLeader >= 0){
+      for(let i=0; i<=lastIdxForLeader; i++){
+        const key = dMeta[i].key;
+        planAcc += planCounts[r][key] || 0;
+        doneAcc += doneCounts[r][key] || 0;
+      }
+    }
+    const pct = planAcc ? Math.round((doneAcc/planAcc)*100) : (doneAcc>0 ? 100 : 0);
+    return { name: cap(r), plan: planAcc, done: doneAcc, pct };
+  }).sort((a,b)=> b.done - a.done);
+
+  const generalPlanTotal = (planRowsGeneral||[]).reduce((acc,p)=>{
+    const resp = normResp(p.responsable);
+    if(allowed.size && !allowed.has(resp)) return acc;
+    return acc + (Number(p.valor)||0);
+  }, 0);
+  const generalDoneTotal = generalGroups.size;
+  const generalPct = generalPlanTotal ? Math.round((generalDoneTotal/generalPlanTotal)*100) : 0;
+
+  renderHeaderKpis({
+    generalPlan: generalPlanTotal,
+    generalDone: generalDoneTotal,
+    generalPct,
+    generalRange: `${generalStart} → ${generalEnd}`,
+    todayPlan: planToToday,
+    todayDone: doneToToday,
+    todayPct,
+    todayRange: `${start} → ${cutoffKey}${cutoffSuffix}`,
+    leaders
+  });
 
   // Render tabla
   let html = "<tr>";
   html += `<th class="sticky l1">RESPONSABLE</th>`;
+  html += `<th class="sticky l2">TIPO</th>`;
   dMeta.forEach(({key,dow})=>{
     const d = parseYmd(key);
-    const cls = dow===0 ? "col-sun" : (dow===6 ? "col-sat" : "");
+    const clsBase = dow===0 ? "col-sun" : (dow===6 ? "col-sat" : "");
+    const clsToday = key===todayKey ? "today-col" : "";
+    const cls = `${clsBase} ${clsToday}`.trim();
     html += `<th class="${cls}">${String(d.getDate()).padStart(2,'0')}<div class="muted">${["Dom","Lun","Mar","Mié","Jue","Vie","Sáb"][dow]}</div></th>`;
   });
   html += `<th>Total</th></tr>`;
 
   resps.forEach(r=>{
-    // Fila plan (editable solo L-V)
-    html += `<tr>`;
-    html += `<td class="sticky l1"><b>${cap(r)}</b> — <span class="muted">Planificado</span></td>`;
+    const respLabel = esc(cap(r));
+    const commentCols = new Map();
+
+    // Fila planificado
     let rowPlan = 0;
+    html += `<tr class="plan-row">`;
+    html += `<td class="sticky l1" rowspan="2"><div class="resp-cell">${respLabel}</div></td>`;
+    html += `<td class="sticky l2 type-cell">Planificado</td>`;
     dMeta.forEach(({key,dow})=>{
       const val = planCounts[r][key] || 0; rowPlan += val;
-      const baseCls = (dow===0 ? "col-sun" : (dow===6 ? "col-sat" : ""));
-      const zeroCls = (val===0 && dow!==0 && dow!==6) ? "plan-zero" : "";
+      const comment = planComments[r][key] || "";
+      const trimmed = comment.trim().toLowerCase();
+      const isBajada = trimmed === "bajada";
+      const hasComment = !!comment;
+      if(hasComment) commentCols.set(key, { isBajada });
+      const classes = [
+        dow===0 ? "col-sun" : (dow===6 ? "col-sat" : ""),
+        key===todayKey ? "today-col" : "",
+        hasComment ? `comment-cell${isBajada ? " comment-bajada" : ""}` : ""
+      ].filter(Boolean).join(" ");
+      const showPin = rpEditMode || hasComment;
+      const pinClasses = ["comment-pin"];
+      if(hasComment) pinClasses.push("has-comment");
+      else if(rpEditMode) pinClasses.push("empty");
+      if(isBajada) pinClasses.push("bajada");
+      const ariaLabel = hasComment
+        ? (rpEditMode ? "Editar comentario" : "Ver comentario")
+        : "Agregar comentario";
+      const pinHtml = showPin
+        ? `<button type="button" class="${pinClasses.join(" ")}" data-resp="${r}" data-date="${key}" aria-label="${esc(ariaLabel)}"></button>`
+        : "";
+
       if(rpEditMode){
-        if(dow===0 || dow===6){
-          html += `<td class="${baseCls}"><input class="ovr-input" type="number" min="0" value="${val}" disabled></td>`;
-        }else{
-          html += `<td class="${baseCls} ${zeroCls}"><input class="ovr-input" data-resp="${r}" data-date="${key}" type="number" min="0" value="${val}"></td>`;
-        }
+        const disabled = (dow===0 || dow===6) ? "disabled" : "";
+        html += `<td class="${classes}">
+          <div class="plan-cell">
+            <input class="ovr-input" data-resp="${r}" data-date="${key}" type="number" min="0" value="${val}" ${disabled}>
+            ${pinHtml}
+          </div>
+        </td>`;
       }else{
-        html += `<td class="${baseCls} ${zeroCls}">${val}</td>`;
+        html += `<td class="${classes}">
+          <div class="plan-cell readonly"><span class="value">${val}</span>${pinHtml}</div>
+        </td>`;
       }
     });
     html += `<td><b>${rowPlan}</b></td>`;
     html += `</tr>`;
 
     // Fila elaborado
-    html += `<tr>`;
-    html += `<td class="sticky l1"><b>${cap(r)}</b> — <span class="muted">Elaborado</span></td>`;
     let rowDone = 0;
+    html += `<tr class="done-row">`;
+    html += `<td class="sticky l2 type-cell">Elaborado</td>`;
     dMeta.forEach(({key,dow})=>{
       const n = doneCounts[r][key] || 0; rowDone += n;
-      const baseCls = (dow===0 ? "col-sun" : (dow===6 ? "col-sat" : ""));
+      const commentMeta = commentCols.get(key);
+      const hasComment = !!commentMeta;
+      const isBajada = commentMeta?.isBajada;
+      const classes = [
+        dow===0 ? "col-sun" : (dow===6 ? "col-sat" : ""),
+        key===todayKey ? "today-col" : "",
+        hasComment ? `comment-cell comment-linked${isBajada ? " comment-bajada" : ""}` : ""
+      ].filter(Boolean).join(" ");
       if(n>0){
-        html += `<td class="${baseCls} clickable" onclick="openRpCell('${r}','${key}')"><b>${n}</b></td>`;
+        html += `<td class="${classes} clickable" onclick="openRpCell('${r}','${key}')"><b>${n}</b></td>`;
       }else{
-        html += `<td class="${baseCls} muted">0</td>`;
+        html += `<td class="${classes} muted">0</td>`;
       }
     });
     html += `<td><b>${rowDone}</b></td>`;
@@ -846,18 +1226,19 @@ async function runReport(){
 
   rpTable.innerHTML = html;
 
-  // Guardado inline (y pinta rojo cuando es 0)
+  // Mantener fija la columna de responsables: no centrar automáticamente en la columna de hoy
+  // scrollReportToToday(todayIdx);
+
+  // Guardado inline
   rpTable.querySelectorAll(".ovr-input:not([disabled])").forEach(inp=>{
     inp.addEventListener("change", async (e)=>{
       const resp = e.target.getAttribute("data-resp");
       const fecha = e.target.getAttribute("data-date");
       const valor = Number(e.target.value)||0;
       try{
-        await savePlan(resp, fecha, valor);
-        // coloreo cero/no-cero
-        const td = e.target.closest("td");
-        if(td){ td.classList.toggle("plan-zero", valor===0); }
+        await savePlanEntry(resp, fecha, { valor });
         rpStatus.textContent = "Planificado guardado ✓";
+        await runReport();
       }catch(err){
         console.error(err);
         rpStatus.textContent = "Error al guardar planificado";
@@ -865,17 +1246,108 @@ async function runReport(){
     });
   });
 
-  // Gráfico de totales diarios (sin desfase)
+  // Comentarios
+  rpTable.querySelectorAll(".comment-pin").forEach(btn=>{
+    btn.addEventListener("click", (e)=>{
+      e.stopPropagation();
+      const resp = btn.getAttribute("data-resp");
+      const fecha = btn.getAttribute("data-date");
+      const current = window._rp_planComments?.[resp]?.[fecha] || "";
+      openCommentPopover({ resp, fecha, anchor: btn, comment: current, editable: rpEditMode });
+    });
+  });
+
+  // Gráfico curva S (acumulados)
   const labels = dMeta.map(({key})=>{
     const d = parseYmd(key); return `${String(d.getDate()).padStart(2,'0')}/${String(d.getMonth()+1).padStart(2,'0')}`;
   });
-  const totals = dMeta.map(({key}) => resps.reduce((acc,r)=> acc + (doneCounts[r][key]||0), 0));
-  renderReportChart(labels, totals);
+  const planCum = [];
+  planDaily.reduce((acc,v)=>{ const next=acc+v; planCum.push(next); return next; },0);
+
+  const doneCum = [];
+  doneDaily.reduce((acc,v,idx)=>{
+    if(todayIdx>=0 && idx>todayIdx){ doneCum.push(null); return acc; }
+    const next = acc+v; doneCum.push(next); return next;
+  },0);
+
+  renderReportCurve(labels, planCum, doneCum, todayIdx);
 
   // Exponer mapa para detalle
   window._rp_cellMapDone = cellMapDone;
 
   rpStatus.textContent = "Listo.";
+}
+
+function buildGroupsMap(rows, allowed = new Set()){
+  const map = new Map();
+  (rows||[]).forEach(r=>{
+    const resp = normResp(r?.responsable);
+    if(!resp) return;
+    if(allowed.size && !allowed.has(resp)) return;
+    const key = r?.unir;
+    if(key == null) return;
+    if(!map.has(key)){
+      map.set(key, {
+        responsable: resp,
+        fecha: (r.fecha_elab||"").toString().slice(0,10),
+        comunidad: r.comunidad || "",
+        codigo_mtc: r.codigo_mtc || "",
+        unirId: key,
+        cods: []
+      });
+    }
+    map.get(key).cods.push(r.cod_prel || "");
+  });
+  return map;
+}
+
+function renderHeaderKpis({ generalPlan, generalDone, generalPct, generalRange, todayPlan, todayDone, todayPct, todayRange, leaders }){
+  const fmt = (n) => numberFormatter.format(Math.round(n || 0));
+  const setText = (id, val) => {
+    const el = document.getElementById(id);
+    if(el) el.textContent = val;
+  };
+
+  setText('kpiGeneralPlan', fmt(generalPlan));
+  setText('kpiGeneralDone', fmt(generalDone));
+  setText('kpiGeneralPct', `${Math.round(generalPct||0)}%`);
+  setText('kpiGeneralPlanRange', generalRange);
+  setText('kpiGeneralDoneRange', generalRange);
+
+  setText('kpiTodayPlan', fmt(todayPlan));
+  setText('kpiTodayDone', fmt(todayDone));
+  setText('kpiTodayPct', `${Math.round(todayPct||0)}%`);
+  setText('kpiTodayRange', todayRange);
+
+  const listEl = document.getElementById('kpiLeaderList');
+  if(!listEl) return;
+  if(!leaders || leaders.length === 0){
+    listEl.innerHTML = '<div class="muted">Sin responsables en el rango.</div>';
+    return;
+  }
+
+  listEl.innerHTML = leaders.map(l => {
+    const pct = Math.round(l.pct || 0);
+    const barPct = Math.max(0, Math.min(100, pct));
+    const doneLabel = fmt(l.done);
+    const planLabel = l.plan > 0 ? fmt(l.plan) : null;
+    const badgeText = planLabel ? `${doneLabel} / ${planLabel}` : `${doneLabel}`;
+    const planCaption = planLabel ? 'Elaborados / planificados' : 'Elaborados';
+    const planText = planLabel ? `${planLabel} planificados` : 'Sin plan definido';
+    return `
+      <div class="leader-item">
+        <div class="leader-head">
+          <span>${esc(l.name)}</span>
+          <span>${pct}%</span>
+        </div>
+        <div class="leader-meta">
+          <span class="badge" title="${esc(planCaption)}">${esc(badgeText)}</span>
+          <span>${esc(planText)}</span>
+        </div>
+        <div class="leader-progress"><span style="width:${barPct}%"></span></div>
+      </div>
+    `;
+  }).join('');
 }
 
 // Detalle de una celda (lista de grupos UNIR con sus códigos clicables)
@@ -922,22 +1394,82 @@ async function selectFromReport(unir, cod){
   }
 }
 
-function renderReportChart(labels, totals){
+const TodayLinePlugin = {
+  id:'todayLine',
+  afterDatasetsDraw(chart, args, opts){
+    const idx = opts?.index;
+    if(idx == null || idx < 0) return;
+    const {ctx, chartArea, scales} = chart;
+    if(!chartArea || !scales?.x) return;
+    const x = scales.x.getPixelForValue(idx);
+    ctx.save();
+    ctx.strokeStyle = 'rgba(99,102,241,.6)';
+    ctx.setLineDash([4,4]);
+    ctx.beginPath();
+    ctx.moveTo(x, chartArea.top);
+    ctx.lineTo(x, chartArea.bottom);
+    ctx.stroke();
+    ctx.setLineDash([]);
+    ctx.fillStyle = '#312e81';
+    ctx.font = '12px system-ui, sans-serif';
+    ctx.fillText('Hoy', x + 6, chartArea.top + 14);
+    ctx.restore();
+  }
+};
+let todayPluginRegistered = false;
+
+function renderReportCurve(labels, planCum, doneCum, todayIdx){
   document.getElementById("chartWrap").style.display = "block";
   const ctx = document.getElementById("rp_chart").getContext("2d");
   if(rpChart) rpChart.destroy();
+  if(!todayPluginRegistered){ Chart.register(TodayLinePlugin); todayPluginRegistered = true; }
   rpChart = new Chart(ctx, {
-    type: 'bar',
+    type: 'line',
     data: {
       labels,
-      datasets: [{ label: 'Elaborados por día (UNIR)', data: totals }]
+      datasets: [
+        {
+          label: 'Planificado acumulado',
+          data: planCum,
+          tension: 0.3,
+          borderColor: '#0ea5e9',
+          backgroundColor: 'rgba(14,165,233,.12)',
+          fill: false,
+          pointRadius: 3
+        },
+        {
+          label: 'Elaborado acumulado',
+          data: doneCum,
+          tension: 0.3,
+          borderColor: '#22c55e',
+          backgroundColor: 'rgba(34,197,94,.12)',
+          fill: false,
+          pointRadius: 3,
+          spanGaps: true
+        }
+      ]
     },
-    options: { responsive:true, maintainAspectRatio:false, scales:{ y:{ beginAtZero:true } } }
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: { position: 'top' },
+        tooltip: { enabled: true },
+        todayLine: { index: todayIdx }
+      },
+      scales: {
+        y: {
+          beginAtZero: true,
+          ticks: { precision: 0 }
+        }
+      }
+    }
   });
 }
 
 function esc(s){ return (s??"").toString().replace(/[&<>"']/g, m=>({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[m])); }
 function cap(r){ return (r||"").replace(/\b\w/g,m=>m.toUpperCase()); }
+function normResp(v){ return (v??"").toString().trim().toLowerCase(); }
 
 /** ====== RESIZER ====== **/
 (function initGutter(){


### PR DESCRIPTION
## Summary
- replace the bulky comment buttons with compact pins that preserve column width while keeping the popover editor/viewer
- lock the responsible and type columns with shared sticky widths so they stay fixed during horizontal scroll without gaps
- refresh the leader KPI card with progress bars and elaborated/plan counts for a clearer responsible overview

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5829ef51083229c6d12f1a1ff5f21