### PR TITLE
Generate Excel export with separate cod_prel columns

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,6 +225,8 @@ on:relative}
     /* Modal EXPEDIENTES específico */
     #expModal .modal{ width:min(1100px,95vw); }
     #exp_table_wrap{ margin-top:8px; border:1px solid #eee; border-radius:10px; background:#fff; max-height:62vh; overflow:auto; }
+    #exp_table th.sortable{ cursor:pointer; user-select:none; background:#f8fafc; }
+    #exp_table th.sortable:hover{ background:#f1f5f9; }
     #exp_table td{ text-align:left; }
     #exp_table .cod-badges{ display:flex; flex-wrap:wrap; gap:6px; justify-content:flex-start; }
     #exp_table .cod-badges .badge{ display:inline-flex; align-items:center; justify-content:center; padding:4px 8px; border-radius:999px; border:1px solid #cbd5e1; background:#eef2ff; font-size:12px; color:#1e293b; white-space:nowrap; }
@@ -456,6 +458,7 @@ on:relative}
           <select id="exp_resp"><option value="">Todos</option></select>
         </label>
         <button class="btn" id="exp_run">Filtrar</button>
+        <button class="ghost" id="exp_export">⬇️ Exportar Excel</button>
         <span id="exp_counter"></span>
       </div>
       <div id="exp_table_wrap">
@@ -1024,12 +1027,17 @@ const expEnd         = document.getElementById('exp_end');
 const expGrupo       = document.getElementById('exp_grupo');
 const expResp        = document.getElementById('exp_resp');
 const expRun         = document.getElementById('exp_run');
+const expExport      = document.getElementById('exp_export');
 const expTable       = document.getElementById('exp_table');
 const expCounter     = document.getElementById('exp_counter');
+
+let expItems = [];
+let expSort  = { column: 'comunidad', direction: 'asc' };
 
 btnExpedientes.addEventListener('click', openExpModal);
 expCloseBtn.addEventListener('click', closeExpModal);
 expRun.addEventListener('click', runExpedientes);
+expExport.addEventListener('click', exportExpedientes);
 
 function openExpModal(){
   defaultExpDates();
@@ -1103,27 +1111,30 @@ async function runExpedientes(){
   const items = [...map.values()].map(item=>({
     ...item,
     cods: item.cods.sort((a,b)=> a.localeCompare(b))
-  })).sort((a,b)=>{
-    const c = (a.comunidad||"").localeCompare(b.comunidad||"");
-    if(c !== 0) return c;
-    return (a.mtc||"").localeCompare(b.mtc||"");
-  });
+  }));
 
+  expItems = items;
   expCounter.textContent = `${items.length} ${items.length===1?'expediente':'expedientes'}`;
+  renderExpTable();
+}
+
+function renderExpTable(){
+  const sortedItems = sortExpItems(expItems.slice());
 
   let html = `
     <thead>
       <tr>
-        <th>Comunidad</th>
-        <th>Código MTC</th>
-        <th>cod_prel</th>
-        <th>Titular</th>
+        <th class="sortable" data-sort="comunidad">Comunidad${getExpSortIndicator('comunidad')}</th>
+        <th class="sortable" data-sort="mtc">Código MTC${getExpSortIndicator('mtc')}</th>
+        <th class="sortable" data-sort="cods">cod_prel${getExpSortIndicator('cods')}</th>
+        <th class="sortable" data-sort="titular">Titular${getExpSortIndicator('titular')}</th>
         <th>Acción</th>
       </tr>
     </thead>
     <tbody>
   `;
-  html += items.map(it=>{
+
+  html += sortedItems.map(it=>{
     const codList = it.cods.length ? it.cods.map(c=>`<span class="badge">${esc(c)}</span>`).join('') : '<span class="muted">—</span>';
     const firstCod = it.primaryCod || it.cods[0] || "";
     return `
@@ -1136,20 +1147,98 @@ async function runExpedientes(){
       </tr>
     `;
   }).join('');
-  if(items.length === 0){
+
+  if(sortedItems.length === 0){
     html += `<tr><td colspan="5" class="muted" style="text-align:center;padding:20px 0">Sin expedientes</td></tr>`;
   }
   html += `</tbody>`;
   expTable.innerHTML = html;
 
+  expTable.querySelectorAll('th[data-sort]').forEach(th=>{
+    th.addEventListener('click', ()=>{
+      const column = th.getAttribute('data-sort');
+      if(expSort.column === column){
+        expSort.direction = expSort.direction === 'asc' ? 'desc' : 'asc';
+      }else{
+        expSort.column = column;
+        expSort.direction = 'asc';
+      }
+      renderExpTable();
+    });
+  });
+
   // Enfocar desde el reporte
-  document.querySelectorAll('.btn-focus-exp').forEach(btn=>{
+  expTable.querySelectorAll('.btn-focus-exp').forEach(btn=>{
     btn.addEventListener('click', async ()=>{
       const unir = btn.getAttribute('data-unir');
       const cod  = btn.getAttribute('data-cod');
       await focusExpediente(unir, cod);
     });
   });
+}
+
+function sortExpItems(items){
+  const column = expSort.column;
+  const dir = expSort.direction === 'asc' ? 1 : -1;
+  const getKey = (item)=>{
+    switch(column){
+      case 'mtc': return item.mtc || '';
+      case 'cods': return item.cods[0] || '';
+      case 'titular': return item.titular || '';
+      case 'comunidad':
+      default:
+        return item.comunidad || '';
+    }
+  };
+  return items.sort((a,b)=>{
+    const ka = getKey(a);
+    const kb = getKey(b);
+    const cmp = ka.localeCompare(kb, undefined, { sensitivity:'base', numeric:true });
+    if(cmp !== 0) return cmp * dir;
+    // fallback to comunidad then mtc for stability
+    const fallback = (a.comunidad||'').localeCompare(b.comunidad||'', undefined, { sensitivity:'base', numeric:true });
+    if(fallback !== 0) return fallback;
+    return (a.mtc||'').localeCompare(b.mtc||'', undefined, { sensitivity:'base', numeric:true });
+  });
+}
+
+function getExpSortIndicator(column){
+  if(expSort.column !== column) return '';
+  return expSort.direction === 'asc' ? ' ▲' : ' ▼';
+}
+
+function exportExpedientes(){
+  if(!expItems.length){ alert('No hay datos para exportar'); return; }
+  const sortedItems = sortExpItems(expItems.slice());
+  const maxCods = Math.max(1, sortedItems.reduce((max,item)=>Math.max(max,item.cods?.length||0),0));
+  const codHeaders = Array.from({length:maxCods},(_,i)=>`cod_prel ${i+1}`);
+  const headers = ['Comunidad','Código MTC', ...codHeaders, 'Titular'];
+  const tableRows = sortedItems.map(item=>{
+    const codCells = Array.from({length:maxCods},(_,i)=>htmlEscape(item.cods?.[i] || ''));
+    return `    <tr><td>${htmlEscape(item.comunidad||'')}</td><td>${htmlEscape(item.mtc||'')}</td>${codCells.map(c=>`<td>${c}</td>`).join('')}<td>${htmlEscape(item.titular||'')}</td></tr>`;
+  });
+  const tableHtml = `<!DOCTYPE html><html lang="es"><head><meta charset="UTF-8"></head><body><table border="1"><thead><tr>${headers.map(h=>`<th>${htmlEscape(h)}</th>`).join('')}</tr></thead><tbody>\n${tableRows.join('\n')}\n  </tbody></table></body></html>`;
+  const bom = '\uFEFF';
+  const blob = new Blob([bom + tableHtml], { type:'application/vnd.ms-excel;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  const start = expStart.value || 'inicio';
+  const end = expEnd.value || 'fin';
+  link.download = `reporte_expedientes_${start}_${end}.xls`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+function htmlEscape(value){
+  return (value ?? '').toString()
+    .replace(/&/g,'&amp;')
+    .replace(/</g,'&lt;')
+    .replace(/>/g,'&gt;')
+    .replace(/"/g,'&quot;')
+    .replace(/'/g,'&#39;');
 }
 
 // Enfocar helper


### PR DESCRIPTION
## Summary
- generate the expediente report export as an Excel-compatible HTML workbook with UTF-8 encoding
- place each cod_prel value in its own column while preserving sorting order

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f16a9964ac83228d0628194d52eee2